### PR TITLE
[update] exclude ArrayDeclaration Keys sniffs

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -78,6 +78,8 @@
         <exclude name="Squiz.Arrays.ArrayDeclaration.ValueNoNewline" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.MultiLineNotAllowed" />
         <exclude name="Squiz.Arrays.ArrayDeclaration.SingleLineNotAllowed" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.KeySpecified" />
+        <exclude name="Squiz.Arrays.ArrayDeclaration.NoKeySpecified" />
     </rule>
 
     <rule ref="Generic.Formatting.SpaceAfterNot" />


### PR DESCRIPTION
These ArrayDeclaration sniffs don't like the way Laravel conditionally creates arrays with mergeWhen()

https://laravel.com/docs/6.x/eloquent-resources

